### PR TITLE
Update lodash version to ^4.17.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/facundoolano/socketio-auth",
   "dependencies": {
     "debug": "^2.1.3",
-    "lodash": "^3.8.0"
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "jscs": "~1.8.0",


### PR DESCRIPTION
This should resolve warnings related to
https://nodesecurity.io/advisories/577