### PR TITLE
Update lodash version to ^4.17.5 with lodash fix

### DIFF
--- a/lib/socketio-auth.js
+++ b/lib/socketio-auth.js
@@ -90,7 +90,7 @@ function forbidConnections(nsp) {
  * If the socket attempted a connection before authentication, restore it.
  */
 function restoreConnection(nsp, socket) {
-  if (_.findWhere(nsp.sockets, {id: socket.id})) {
+  if (_.find(nsp.sockets, {id: socket.id})) {
     debug('restoring socket to %s', nsp.name);
     nsp.connected[socket.id] = socket;
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/facundoolano/socketio-auth",
   "dependencies": {
     "debug": "^2.1.3",
-    "lodash": "^3.8.0"
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "jscs": "~1.8.0",


### PR DESCRIPTION
This should resolve warnings related to
https://nodesecurity.io/advisories/577

I'm pretty sure I fixed the issue with the lodash update that was causing a break in the test.